### PR TITLE
Support Data Streams for Bulk

### DIFF
--- a/src/main/java/io/kestra/plugin/elasticsearch/Bulk.java
+++ b/src/main/java/io/kestra/plugin/elasticsearch/Bulk.java
@@ -14,6 +14,7 @@ import lombok.NoArgsConstructor;
 import lombok.ToString;
 import lombok.experimental.SuperBuilder;
 import org.opensearch.client.opensearch.core.bulk.BulkOperation;
+import org.opensearch.client.opensearch.core.bulk.CreateOperation;
 import org.opensearch.client.opensearch.core.bulk.DeleteOperation;
 import org.opensearch.client.opensearch.core.bulk.IndexOperation;
 import org.opensearch.client.opensearch.core.bulk.UpdateOperation;
@@ -51,7 +52,7 @@ import static io.kestra.core.utils.Rethrow.throwConsumer;
                   - id: bulk_load
                     type: io.kestra.plugin.elasticsearch.Bulk
                     connection:
-                      hosts: 
+                      hosts:
                        - "http://localhost:9200"
                     from: "{{ inputs.file }}"
                 """
@@ -87,12 +88,12 @@ public class Bulk extends AbstractLoad implements RunnableTask<Bulk.Output> {
                         bulkOperation.index(indexOperation.build());
                         break;
                     case "create":
-                        var createOperation = new IndexOperation.Builder<>()
+                        var createOperation = new CreateOperation.Builder<>()
                             .id((String) value.get("_id"))
                             .index((String) value.get("_index"))
                             .ifPrimaryTerm(0L) //FIXME opType
                             .document(parseline(input.readLine()));
-                        bulkOperation.index(createOperation.build());
+                        bulkOperation.create(createOperation.build());
                         break;
                     case "update":
                         var updateOperation = new UpdateOperation.Builder<>()


### PR DESCRIPTION
Add support for writing into Data stream with the bulk mode

### What changes are being made and why?
The operation **create** must be used instead of **index** when writing,  this adds support for the bulk operations with [Data streams](https://www.elastic.co/guide/en/elasticsearch/reference/current/data-streams.html) as they are Append-only indexes

