### PR TITLE
fix: rename version property to docVersion on Get task

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 version=0.22.0-SNAPSHOT
-kestraVersion=[0.21,)
+kestraVersion=[0.22,)
 elasticsearchVersion=8.16.0

--- a/src/main/java/io/kestra/plugin/elasticsearch/Get.java
+++ b/src/main/java/io/kestra/plugin/elasticsearch/Get.java
@@ -6,7 +6,6 @@ import co.elastic.clients.elasticsearch.core.GetResponse;
 import co.elastic.clients.transport.rest_client.RestClientTransport;
 import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Plugin;
-import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.models.tasks.RunnableTask;
 import io.kestra.core.runners.RunContext;
@@ -60,11 +59,11 @@ public class Get extends AbstractTask implements RunnableTask<Get.Output> {
     private Property<String> key;
 
     @Schema(
-        title = "Sets the version",
-        description = "which will cause the get operation to only be performed if a matching version exists and no changes happened on the doc since then."
+        title = "Current version of the document",
+        description = " The specified version must match the current version of the document for the GET request to succeed."
     )
     @NotNull
-    private Property<Long> version;
+    private Property<Long> docVersion;
 
     @Override
     public Get.Output run(RunContext runContext) throws Exception {
@@ -77,8 +76,8 @@ public class Get extends AbstractTask implements RunnableTask<Get.Output> {
             var request = new GetRequest.Builder();
             request.index(index).id(key);
 
-            if (this.version != null) {
-                request.version(runContext.render(this.version).as(Long.class).orElseThrow());
+            if (this.docVersion != null) {
+                request.version(runContext.render(this.docVersion).as(Long.class).orElseThrow());
             }
 
             if (this.routing != null) {

--- a/src/test/resources/sanity-checks/bulk.yaml
+++ b/src/test/resources/sanity-checks/bulk.yaml
@@ -36,7 +36,7 @@ tasks:
         - "{{ inputs.cs }}"
     index: "{{ vars.index_name }}"
     key: "3"
-    version: 2
+    docVersion: 2
 
   - id: assert
     type: io.kestra.plugin.core.execution.Assert

--- a/src/test/resources/sanity-checks/put_get.yaml
+++ b/src/test/resources/sanity-checks/put_get.yaml
@@ -41,7 +41,7 @@ tasks:
         - "{{ inputs.cs }}"
     index: "{{ vars.index_name }}"
     key: "{{ vars.document_key }}"
-    version: 1
+    docVersion: 1
 
   - id: assert
     type: io.kestra.plugin.core.execution.Assert


### PR DESCRIPTION
Change:
* renaming existing version property to not conflict with new global task property 'version'

breaking-change