### PR TITLE
fix(core): migrate FileSerde to InputStream/OutputStream API for binary ION support

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 version=1.5.3-SNAPSHOT
-kestraVersion=1.3.13
+kestraVersion=1.3.19
 elasticsearchVersion=9.3.0

--- a/src/main/java/io/kestra/plugin/elasticsearch/AbstractLoad.java
+++ b/src/main/java/io/kestra/plugin/elasticsearch/AbstractLoad.java
@@ -1,8 +1,8 @@
 package io.kestra.plugin.elasticsearch;
 
-import java.io.BufferedReader;
+import java.io.BufferedInputStream;
 import java.io.IOException;
-import java.io.InputStreamReader;
+import java.io.InputStream;
 import java.net.URI;
 import java.time.Duration;
 import java.util.concurrent.atomic.AtomicLong;
@@ -53,7 +53,7 @@ public abstract class AbstractLoad extends AbstractTask implements RunnableTask<
     @PluginProperty(group = "execution")
     private Property<Integer> chunk = Property.ofValue(1000);
 
-    abstract protected Flux<BulkOperation> source(RunContext runContext, BufferedReader inputStream) throws IllegalVariableEvaluationException, IOException;
+    abstract protected Flux<BulkOperation> source(RunContext runContext, InputStream inputStream) throws IllegalVariableEvaluationException, IOException;
 
     @Override
     public AbstractLoad.Output run(RunContext runContext) throws Exception {
@@ -61,7 +61,7 @@ public abstract class AbstractLoad extends AbstractTask implements RunnableTask<
 
         try (
             ElasticsearchClient client = this.connection.highLevelClient(runContext);
-            BufferedReader inputStream = new BufferedReader(new InputStreamReader(runContext.storage().getFile(from)), FileSerde.BUFFER_SIZE)
+            InputStream inputStream = new BufferedInputStream(runContext.storage().getFile(from), FileSerde.BUFFER_SIZE)
         ) {
             Integer bufferSize = runContext.render(this.chunk).as(Integer.class).orElseThrow();
             Flux<BulkOperation> operationFlux = this.source(runContext, inputStream);

--- a/src/main/java/io/kestra/plugin/elasticsearch/Bulk.java
+++ b/src/main/java/io/kestra/plugin/elasticsearch/Bulk.java
@@ -2,6 +2,8 @@ package io.kestra.plugin.elasticsearch;
 
 import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.util.Map;
 import java.util.function.Consumer;
 
@@ -71,9 +73,9 @@ public class Bulk extends AbstractLoad implements RunnableTask<Bulk.Output> {
     private static final ObjectMapper OBJECT_MAPPER = JacksonMapper.ofJson();
 
     @Override
-    protected Flux<BulkOperation> source(RunContext runContext, BufferedReader inputStream) throws IOException {
+    protected Flux<BulkOperation> source(RunContext runContext, InputStream inputStream) throws IOException {
         return Flux
-            .create(this.fileReader(inputStream), FluxSink.OverflowStrategy.BUFFER);
+            .create(this.fileReader(new BufferedReader(new InputStreamReader(inputStream))), FluxSink.OverflowStrategy.BUFFER);
     }
 
     @SuppressWarnings("unchecked")

--- a/src/main/java/io/kestra/plugin/elasticsearch/Esql.java
+++ b/src/main/java/io/kestra/plugin/elasticsearch/Esql.java
@@ -1,16 +1,27 @@
 package io.kestra.plugin.elasticsearch;
 
-import co.elastic.clients.elasticsearch.ElasticsearchClient;
-import co.elastic.clients.elasticsearch._helpers.esql.EsqlAdapter;
-import co.elastic.clients.elasticsearch.core.SearchRequest;
-import co.elastic.clients.elasticsearch.esql.EsqlFormat;
-import co.elastic.clients.elasticsearch.esql.QueryRequest;
-import co.elastic.clients.json.JsonpUtils;
-import co.elastic.clients.transport.endpoints.BinaryResponse;
-import co.elastic.clients.transport.rest5_client.low_level.Rest5Client;
+import java.io.BufferedOutputStream;
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.tuple.Pair;
+import org.slf4j.Logger;
+
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.Iterables;
+
 import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Metric;
 import io.kestra.core.models.annotations.Plugin;
@@ -22,28 +33,20 @@ import io.kestra.core.models.tasks.common.FetchType;
 import io.kestra.core.runners.RunContext;
 import io.kestra.core.serializers.FileSerde;
 import io.kestra.core.serializers.JacksonMapper;
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch._helpers.esql.EsqlAdapter;
+import co.elastic.clients.elasticsearch.core.SearchRequest;
+import co.elastic.clients.elasticsearch.esql.EsqlFormat;
+import co.elastic.clients.elasticsearch.esql.QueryRequest;
+import co.elastic.clients.json.JsonpUtils;
+import co.elastic.clients.transport.endpoints.BinaryResponse;
+import co.elastic.clients.transport.rest5_client.low_level.Rest5Client;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
-import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang3.tuple.Pair;
-import org.slf4j.Logger;
 import reactor.core.publisher.Flux;
-
-import java.io.BufferedWriter;
-import java.io.ByteArrayInputStream;
-import java.io.File;
-import java.io.FileWriter;
-import java.io.IOException;
-import java.io.InputStream;
-import java.net.URI;
-import java.util.List;
-import java.util.Map;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-import java.util.stream.Collectors;
-import java.util.stream.StreamSupport;
 
 import static io.kestra.core.utils.Rethrow.throwFunction;
 
@@ -155,7 +158,6 @@ public class Esql extends AbstractTask implements RunnableTask<Esql.Output> {
     @PluginProperty(dynamic = true, group = "connection")
     private Property<Boolean> async = Property.ofValue(false);
 
-
     @Override
     public Esql.Output run(RunContext runContext) throws Exception {
         Logger logger = runContext.logger();
@@ -171,20 +173,19 @@ public class Esql extends AbstractTask implements RunnableTask<Esql.Output> {
             String finalQuery = interpolateParams(renderedQuery, rParams);
 
             QueryRequest queryRequest = QueryRequest.of(throwFunction(builder ->
-                {
-                    builder.query(finalQuery);
-                    builder.format(EsqlFormat.Json);
-                    builder.columnar(rColumnar);
+            {
+                builder.query(finalQuery);
+                builder.format(EsqlFormat.Json);
+                builder.columnar(rColumnar);
 
-                    if (filter != null) {
-                        SearchRequest.Builder request = QueryService.request(runContext, this.filter);
-                        builder.filter(request.build().query());
-                    }
-
-                    return builder;
+                if (filter != null) {
+                    SearchRequest.Builder request = QueryService.request(runContext, this.filter);
+                    builder.filter(request.build().query());
                 }
-            ));
 
+                return builder;
+            }
+            ));
 
             logger.debug("Starting query: {}", query);
 
@@ -251,8 +252,7 @@ public class Esql extends AbstractTask implements RunnableTask<Esql.Output> {
         ElasticsearchClient client,
         QueryRequest queryRequest,
         EsqlAdapter<Iterable<Map<String, Object>>> adapter,
-        Logger logger
-    ) throws Exception {
+        Logger logger) throws Exception {
         String body = buildAsyncBody(JsonpUtils.toJsonString(queryRequest, client._jsonpMapper()));
 
         try (Rest5Client lowLevel = this.connection.client(runContext)) {
@@ -342,10 +342,10 @@ public class Esql extends AbstractTask implements RunnableTask<Esql.Output> {
      * see <a href="https://www.elastic.co/docs/reference/query-languages/esql/esql-rest#esql-rest-identifier-params">ES documentation</a>
      */
     private static final Pattern QUERY_TOKEN = Pattern.compile(
-        "\"\"\".*?\"\"\""              // triple-quoted raw string
-        + "|\"(?:\\\\.|[^\"\\\\])*\""  // double-quoted string with backslash escapes
-        + "|`[^`]*`"                   // backtick-quoted identifier
-        + "|\\?",                      // anonymous placeholder
+        "\"\"\".*?\"\"\"" // triple-quoted raw string
+            + "|\"(?:\\\\.|[^\"\\\\])*\"" // double-quoted string with backslash escapes
+            + "|`[^`]*`" // backtick-quoted identifier
+            + "|\\?", // anonymous placeholder
         Pattern.DOTALL
     );
 
@@ -394,7 +394,8 @@ public class Esql extends AbstractTask implements RunnableTask<Esql.Output> {
     }
 
     private static Object parse(String s) {
-        if (s == null) return null;
+        if (s == null)
+            return null;
         if (s.equalsIgnoreCase("true") || s.equalsIgnoreCase("false")) {
             return Boolean.parseBoolean(s);
         }
@@ -410,13 +411,13 @@ public class Esql extends AbstractTask implements RunnableTask<Esql.Output> {
             return Double.parseDouble(s);
         } catch (NumberFormatException ignored) {
         }
-        return s;  // fallback: keep as string
+        return s; // fallback: keep as string
     }
 
     protected Pair<URI, Long> store(RunContext runContext, Iterable<Map<String, Object>> searchResponse) throws IOException {
         File tempFile = runContext.workingDir().createTempFile(".ion").toFile();
 
-        try (var output = new BufferedWriter(new FileWriter(tempFile), FileSerde.BUFFER_SIZE)) {
+        try (var output = new BufferedOutputStream(new FileOutputStream(tempFile), FileSerde.BUFFER_SIZE)) {
             Flux<Map<String, Object>> hitFlux = Flux.fromIterable(searchResponse);
             Long count = FileSerde.writeAll(output, hitFlux).block();
 

--- a/src/main/java/io/kestra/plugin/elasticsearch/Load.java
+++ b/src/main/java/io/kestra/plugin/elasticsearch/Load.java
@@ -1,13 +1,14 @@
 package io.kestra.plugin.elasticsearch;
 
-import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.Map;
 
 import io.kestra.core.exceptions.IllegalVariableEvaluationException;
 import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Metric;
 import io.kestra.core.models.annotations.Plugin;
+import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.models.executions.metrics.Counter;
 import io.kestra.core.models.executions.metrics.Timer;
 import io.kestra.core.models.property.Property;
@@ -25,7 +26,6 @@ import lombok.experimental.SuperBuilder;
 import reactor.core.publisher.Flux;
 
 import static io.kestra.core.utils.Rethrow.throwFunction;
-import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -98,7 +98,7 @@ public class Load extends AbstractLoad implements RunnableTask<Load.Output> {
 
     @SuppressWarnings("unchecked")
     @Override
-    protected Flux<BulkOperation> source(RunContext runContext, BufferedReader inputStream) throws IllegalVariableEvaluationException, IOException {
+    protected Flux<BulkOperation> source(RunContext runContext, InputStream inputStream) throws IllegalVariableEvaluationException, IOException {
         return FileSerde.readAll(inputStream)
             .map(throwFunction(o ->
             {

--- a/src/main/java/io/kestra/plugin/elasticsearch/Scroll.java
+++ b/src/main/java/io/kestra/plugin/elasticsearch/Scroll.java
@@ -74,7 +74,7 @@ public class Scroll extends AbstractSearch implements RunnableTask<Scroll.Output
 
         try (
             ElasticsearchClient client = this.connection.highLevelClient(runContext);
-            Writer output = new BufferedWriter(new FileWriter(tempFile), FileSerde.BUFFER_SIZE)
+            OutputStream output = new BufferedOutputStream(new FileOutputStream(tempFile), FileSerde.BUFFER_SIZE)
         ) {
             // build request
             SearchRequest.Builder request = this.request(runContext);

--- a/src/main/java/io/kestra/plugin/elasticsearch/Search.java
+++ b/src/main/java/io/kestra/plugin/elasticsearch/Search.java
@@ -1,8 +1,8 @@
 package io.kestra.plugin.elasticsearch;
 
-import java.io.BufferedWriter;
+import java.io.BufferedOutputStream;
 import java.io.File;
-import java.io.FileWriter;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.net.URI;
 import java.time.Duration;
@@ -16,6 +16,7 @@ import org.slf4j.Logger;
 import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Metric;
 import io.kestra.core.models.annotations.Plugin;
+import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.models.executions.metrics.Counter;
 import io.kestra.core.models.executions.metrics.Timer;
 import io.kestra.core.models.property.Property;
@@ -33,7 +34,6 @@ import lombok.experimental.SuperBuilder;
 import reactor.core.publisher.Flux;
 
 import static io.kestra.core.utils.Rethrow.throwConsumer;
-import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -135,7 +135,7 @@ public class Search extends AbstractSearch implements RunnableTask<Search.Output
     protected Pair<URI, Long> store(RunContext runContext, SearchResponse<Map> searchResponse) throws IOException {
         File tempFile = runContext.workingDir().createTempFile(".ion").toFile();
 
-        try (var output = new BufferedWriter(new FileWriter(tempFile), FileSerde.BUFFER_SIZE)) {
+        try (var output = new BufferedOutputStream(new FileOutputStream(tempFile), FileSerde.BUFFER_SIZE)) {
             Flux<Map> hitFlux = Flux.fromIterable(searchResponse.hits().hits()).map(hit -> hit.source());
             Long count = FileSerde.writeAll(output, hitFlux).block();
 

--- a/src/test/java/io/kestra/plugin/elasticsearch/EsqlTest.java
+++ b/src/test/java/io/kestra/plugin/elasticsearch/EsqlTest.java
@@ -1,19 +1,20 @@
 package io.kestra.plugin.elasticsearch;
 
+import java.io.BufferedInputStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
 import io.kestra.core.models.property.Property;
 import io.kestra.core.models.tasks.common.FetchType;
 import io.kestra.core.runners.RunContext;
 import io.kestra.core.serializers.FileSerde;
 import io.kestra.core.storages.StorageInterface;
 import io.kestra.core.tenant.TenantService;
-import jakarta.inject.Inject;
-import org.junit.jupiter.api.Test;
 
-import java.io.BufferedReader;
-import java.io.InputStreamReader;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
+import jakarta.inject.Inject;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -166,9 +167,9 @@ class EsqlTest extends ElsContainer {
         assertThat(run.getTotal(), is(10L));
         assertThat(run.getUri(), notNullValue());
 
-        BufferedReader inputStream = new BufferedReader(new InputStreamReader(storageInterface.get(TenantService.MAIN_TENANT, null, run.getUri())));
+        var inputStream = new BufferedInputStream(storageInterface.get(TenantService.MAIN_TENANT, null, run.getUri()), FileSerde.BUFFER_SIZE);
         List<Map<String, Object>> result = new ArrayList<>();
-        FileSerde.reader(inputStream, r -> result.add((Map<String, Object>) r));
+        FileSerde.read(inputStream, r -> result.add((Map<String, Object>) r));
 
         assertThat(result.get(8).get("key"), is(925311404));
     }

--- a/src/test/java/io/kestra/plugin/elasticsearch/SearchTest.java
+++ b/src/test/java/io/kestra/plugin/elasticsearch/SearchTest.java
@@ -1,7 +1,6 @@
 package io.kestra.plugin.elasticsearch;
 
-import java.io.BufferedReader;
-import java.io.InputStreamReader;
+import java.io.BufferedInputStream;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -103,9 +102,9 @@ class SearchTest extends ElsContainer {
         assertThat(run.getTotal(), is(28L));
         assertThat(run.getUri(), notNullValue());
 
-        BufferedReader inputStream = new BufferedReader(new InputStreamReader(storageInterface.get(TenantService.MAIN_TENANT, null, run.getUri())));
+        var inputStream = new BufferedInputStream(storageInterface.get(TenantService.MAIN_TENANT, null, run.getUri()), FileSerde.BUFFER_SIZE);
         List<Map<String, Object>> result = new ArrayList<>();
-        FileSerde.reader(inputStream, r -> result.add((Map<String, Object>) r));
+        FileSerde.read(inputStream, r -> result.add((Map<String, Object>) r));
 
         assertThat(result.get(8).get("key"), is(925311404));
     }


### PR DESCRIPTION
Migrate deprecated Reader/Writer-based FileSerde API to InputStream/OutputStream for binary ION compatibility (kestra/kestra#3155).

## Changes
- Bump `kestraVersion` to `1.3.19`
- `AbstractLoad`: `BufferedReader`/`InputStreamReader` → `BufferedInputStream`/`InputStream`
- `Load`: method signature `BufferedReader` → `InputStream`
- `Bulk`: method signature `InputStream`, wraps in `BufferedReader` internally for line-based parsing
- `Search`: `BufferedWriter`/`FileWriter` → `BufferedOutputStream`/`FileOutputStream`
- `Scroll`: `Writer`/`BufferedWriter`/`FileWriter` → `OutputStream`/`BufferedOutputStream`/`FileOutputStream`
- `Esql`: `BufferedWriter`/`FileWriter` → `BufferedOutputStream`/`FileOutputStream`
- Test files (`SearchTest`, `EsqlTest`): `BufferedReader`/`InputStreamReader` → `BufferedInputStream`, `FileSerde.reader()` → `FileSerde.read()`