### PR TITLE
fix(security): remediate OWASP/CWE audit findings (2026-06-30)

### DIFF
--- a/src/main/java/io/kestra/plugin/elasticsearch/ElasticsearchConnection.java
+++ b/src/main/java/io/kestra/plugin/elasticsearch/ElasticsearchConnection.java
@@ -66,7 +66,7 @@ public class ElasticsearchConnection {
         title = "Custom HTTP headers",
         description = "Headers sent on every request in `Name: Value` format, e.g. `Authorization: Token XYZ`."
     )
-    @PluginProperty(group = "advanced")
+    @PluginProperty(group = "advanced", secret = true)
     private Property<List<String>> headers;
 
     @Schema(
@@ -131,6 +131,10 @@ public class ElasticsearchConnection {
         });
 
         if (runContext.render(this.trustAllSsl).as(Boolean.class).orElse(false)) {
+            runContext.logger().warn(
+                "`trustAllSsl` is enabled: TLS certificate and hostname verification are disabled for this Elasticsearch connection. " +
+                    "This makes the connection vulnerable to man-in-the-middle attacks and should only be used with self-signed certificates in non-production environments."
+            );
             try {
                 var sslContext = SSLContexts.custom()
                     .loadTrustMaterial(null, TrustAllStrategy.INSTANCE)


### PR DESCRIPTION
## Summary

Remediates all findings (CRITICAL/HIGH/MEDIUM/LOW) from the 2026-06-30 automated security audit against OWASP Top 10 (2025), CWE Top 25, and OWASP ASVS Level 1.

## Findings Fixed

- **HIGH** — Custom HTTP headers field carrying Authorization tokens lacks `@PluginProperty(secret=true)` — `src/main/java/io/kestra/plugin/elasticsearch/ElasticsearchConnection.java:70` — Added `secret = true` to the `@PluginProperty` annotation on the `headers` field so Authorization/API-key values passed via custom headers are masked in logs, audit trails, and the UI instead of being stored/displayed in cleartext.
- **MEDIUM** — TLS completely disabled (certificate + hostname verification) when `trustAllSsl=true` with no runtime warning — `src/main/java/io/kestra/plugin/elasticsearch/ElasticsearchConnection.java:140` — Added a `runContext.logger().warn(...)` call emitted whenever `trustAllSsl` is enabled, clearly flagging that certificate and hostname verification are disabled and that the connection is vulnerable to man-in-the-middle attacks, so operators get visible, audited feedback at runtime instead of silent insecure behavior.

## Testing

- [ ] `./gradlew build` passes
- [ ] No regressions in existing tests

## References

- Security Audit EPIC: https://github.com/kestra-io/plugin-elasticsearch/issues/108
- [Full Audit Report](https://claude.ai/code/artifact/87ba8c38-c7ec-40ef-8d8e-384da1bfacf4)
- [Org-wide Security Meta-EPIC](https://github.com/kestra-io/kestra-ee/issues/9092)
